### PR TITLE
v2 Installation Guide Changes

### DIFF
--- a/.config/sway/config
+++ b/.config/sway/config
@@ -69,9 +69,6 @@ set $mod Mod1
   ### Start Task Manager:
   bindsym $mod+k exec $taskManager
 
-## Floating Window Dragging:
-  floating_modifier $mod normal
-
 ## Change Focus:
   bindsym $mod+Left focus left
   bindsym $mod+Down focus down
@@ -121,12 +118,17 @@ set $mod Mod1
     bindsym $mod+Shift+k layout tabbed
     #### Toggle Split
     bindsym $mod+Shift+l layout toggle split
+
   ### Toggle Fullscreen for Currently Focused Window:
   bindsym $mod+Return fullscreen
+
   ### Toggle Floating Mode for Currently Focused Window:
   bindsym $mod+Shift+Space floating toggle
   ### Switch Focus Between Floating and Tiling Areas:
   bindsym $mod+Space focus mode_toggle
+  ### Floating Window Dragging:
+  floating_modifier $mod normal
+
   ### Move Focus to Parent Container
   bindsym $mod+Shift+Tab focus parent
   ### Move Focus to Child in Container

--- a/package.use.append
+++ b/package.use.append
@@ -1,0 +1,27 @@
+# Sway
+gui-libs/wlroots drm libinput session
+gui-wm/sway filecaps grimshot swaynag
+media-libs/harfbuzz truetype glib
+media-libs/mesa gles2 zink
+media-libs/freetype png
+
+# Waybar
+gui-apps/waybar pipewire evdev network
+media-fonts/fontawesome ttf
+media-libs/libepoxy egl
+x11-libs/cairo glib
+
+# Suspend to RAM (sleep)
+dev-libs/libgpg-error static-libs
+dev-libs/libgcrypt static-libs
+
+# Firefox
+www-client/firefox system-harfbuzz hwaccel
+media-video/libva-utils vainfo
+dev-lang/python sqlite
+
+# MPV (video player)
+media-libs/libplacebo shaderc
+media-libs/libass fontconfig
+media-video/ffmpeg encode
+media-video/mpv cli

--- a/package.use.append
+++ b/package.use.append
@@ -20,6 +20,9 @@ www-client/firefox system-harfbuzz hwaccel
 media-video/libva-utils vainfo
 dev-lang/python sqlite
 
+# IMV (image viewer)
+media-gfx/imv gif jpeg png svg tiff
+
 # MPV (video player)
 media-libs/libplacebo shaderc
 media-libs/libass fontconfig


### PR DESCRIPTION
Changes in concert with v2 of the Gentoo Installation Guide video:
- `package.use.append` file to cat the Sway-related `USE` flags to the end of the existing `package.use`.
- Sway config tweak to move the floating window move modifier to a more sensible location.