### PR TITLE
Pipewire Fixes

### DIFF
--- a/.config/sway/config
+++ b/.config/sway/config
@@ -18,7 +18,7 @@ set $regionScreenshot grim -g "$(slurp)" - | wl-copy
 # Audio Control Commands
 set $muteAudioOutput wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle
 set $increaseAudioOutput wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+
-set $decreaseAudioOutput wpctl set-colume @DEFAULT_AUDIO_SINK@ 5%-
+set $decreaseAudioOutput wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-
 set $muteAudioInput wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle
 set $increaseAudioInput wpctl set-volume @DEFAULT_AUDIO_SOURCE@ 5%+
 set $decreaseAudioInput wpctl set-volume @DEFAULT_AUDIO_SOURCE@ 5%-
@@ -195,8 +195,9 @@ bar {
 # XWayland Support
 xwayland disable
 
-# Launch pipewire with Sway
+# Launch pipewire & wireplumber with Sway
 exec dbus-launch --exit-with-session pipewire
+exec dbus-launch --exit-with-session wireplumber
 
 # Styling
 ## Run 'man 5 sway' for more information and options.

--- a/package.use.append
+++ b/package.use.append
@@ -1,9 +1,9 @@
 
 # Sway
+media-video/pipewire sound-server pipewire-alsa
 gui-libs/wlroots drm libinput session
 gui-wm/sway filecaps grimshot swaynag
 media-libs/harfbuzz truetype glib
-media-video/pipewire sound-server
 media-libs/mesa gles2 zink
 media-libs/freetype png
 

--- a/package.use.append
+++ b/package.use.append
@@ -1,7 +1,9 @@
+
 # Sway
 gui-libs/wlroots drm libinput session
 gui-wm/sway filecaps grimshot swaynag
 media-libs/harfbuzz truetype glib
+media-video/pipewire sound-server
 media-libs/mesa gles2 zink
 media-libs/freetype png
 


### PR DESCRIPTION
The Pipewire setup previously included was incomplete; the following changes have been made to properly set up Pipewire:
- Add `sound-server` and `pipewire-alsa` to the `media-video/pipewire` package use flags.
- Add `wireplumber` launch to Sway config.
- Correct typo in output volume down command in Sway config.

Users should also run `usermod [username] -aG pipewire` to give their user account control over the pipewire server.